### PR TITLE
chore: change Dependabot update schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,19 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 50
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "node"


### PR DESCRIPTION
Changed the update schedule for npm, GitHub Actions, and Docker to daily